### PR TITLE
Backport fix for CVE-2023-22799

### DIFF
--- a/globalid.gemspec
+++ b/globalid.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'globalid'
-  s.version     = '0.4.2'
+  s.version     = '0.4.2.1'
   s.summary     = 'Refer to any model with a URI: gid://app/class/id'
   s.description = 'URIs for your models makes it easy to pass references around.'
 

--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -123,9 +123,6 @@ module URI
     private
       COMPONENT = [ :scheme, :app, :model_name, :model_id, :params ].freeze
 
-      # Extracts model_name and model_id from the URI path.
-      PATH_REGEXP = %r(\A/([^/]+)/?([^/]+)?\z)
-
       def check_host(host)
         validate_component(host)
         super
@@ -145,11 +142,11 @@ module URI
       end
 
       def set_model_components(path, validate = false)
-        _, model_name, model_id = path.match(PATH_REGEXP).to_a
-        model_id = CGI.unescape(model_id) if model_id
-
+        _, model_name, model_id = path.split('/', 3)
         validate_component(model_name) && validate_model_id(model_id, model_name) if validate
 
+        model_id = CGI.unescape(model_id) if model_id
+        
         @model_name = model_name
         @model_id = model_id
       end
@@ -162,7 +159,7 @@ module URI
       end
 
       def validate_model_id(model_id, model_name)
-        return model_id unless model_id.blank?
+        return model_id unless model_id.blank? || model_id.include?('/')
 
         raise MissingModelIdError, "Unable to create a Global ID for " \
           "#{model_name} without a model id."


### PR DESCRIPTION
Backported fix from https://discuss.rubyonrails.org/t/cve-2023-22799-possible-redos-based-dos-vulnerability-in-globalid/82127